### PR TITLE
fix: cleaning the URL properly

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -62,7 +62,7 @@ export async function getSession(
         } else if (refreshToken) {
             setSessionStorage(refreshToken, projectId);
 
-            // cleanURLFromTokens removes access_token and refresh_token from the URL
+            // Removes access_token and refresh_token from the URL
             // Required otherwise other useful link params are lost
             const url = new URL(window.location.href);
             if (url.hash.includes("access_token") || url.hash.includes("refresh_token")) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -64,27 +64,23 @@ export async function getSession(
 
             // cleanURLFromTokens removes access_token and refresh_token from the URL
             // Required otherwise other useful link params are lost
-            const cleanURLFromTokens = () => {
-                const url = new URL(window.location.href);
-                if (url.hash.includes("access_token") || url.hash.includes("refresh_token")) {
-                    const newHash = url.hash
-                        .substring(1)
-                        .split("&")
-                        .filter(
-                            (param) =>
-                                !param.startsWith("access_token") &&
-                                !param.startsWith("refresh_token"),
-                        )
-                        .join("&");
+            const url = new URL(window.location.href);
+            if (url.hash.includes("access_token") || url.hash.includes("refresh_token")) {
+                const newHash = url.hash
+                    .substring(1)
+                    .split("&")
+                    .filter(
+                        (param) =>
+                            !param.startsWith("access_token") && !param.startsWith("refresh_token"),
+                    )
+                    .join("&");
 
-                    window.history.replaceState(
-                        {},
-                        window.document.title,
-                        `${url.pathname}${url.search}${newHash ? `#${newHash}` : ""}`,
-                    );
-                }
-            };
-            cleanURLFromTokens();
+                window.history.replaceState(
+                    {},
+                    window.document.title,
+                    `${url.pathname}${url.search}${newHash ? `#${newHash}` : ""}`,
+                );
+            }
         }
 
         if (!refreshToken) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -67,20 +67,14 @@ export async function getSession(
             const cleanURLFromTokens = () => {
                 const url = new URL(window.location.href);
                 if (url.hash.includes("access_token") || url.hash.includes("refresh_token")) {
-                    const hashParams = url.hash
+                    const newHash = url.hash
                         .substring(1)
                         .split("&")
-                        .reduce((acc: { [key: string]: string }, current) => {
-                            const [key, value] = current.split("=");
-                            acc[key] = value;
-                            return acc;
-                        }, {});
-
-                    delete hashParams.access_token;
-                    delete hashParams.refresh_token;
-
-                    const newHash = Object.entries(hashParams)
-                        .map(([key, value]) => `${key}=${value}`)
+                        .filter(
+                            (param) =>
+                                !param.startsWith("access_token") &&
+                                !param.startsWith("refresh_token"),
+                        )
                         .join("&");
 
                     window.history.replaceState(

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -71,7 +71,7 @@ export async function getSession(
                     .split("&")
                     .filter(
                         (param) =>
-                            !param.startsWith("access_token") && !param.startsWith("refresh_token"),
+                            !param.startsWith("access_token=") && !param.startsWith("refresh_token="),
                     )
                     .join("&");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "polyfire-js",
-    "version": "0.2.57",
+    "version": "0.2.58",
     "main": "index.js",
     "types": "index.d.ts",
     "author": "Lancelot Owczarczak <lancelot@owczarczak.fr>",


### PR DESCRIPTION
Doing this pull request because the handling of the access_token on auth breaks user experience. When there are other useful params in the path (e.g. ?docId=xxxxx) the cleanup in the code removes everything instead of just the access_token & refresh_token. 

I fixed it by splitting the path and removing just the access_tokens and refresh_tokens and then rebuilding it.